### PR TITLE
add net.Conn impl that wraps free()

### DIFF
--- a/wrap.go
+++ b/wrap.go
@@ -1,0 +1,24 @@
+package connlimit
+
+import "net"
+
+type wrappedConn struct {
+	net.Conn
+	free func()
+}
+
+// Wrap wraps a net.Conn's Close method so free() is called when Close is
+// called. Useful when handing off tracked connections to libraries that close
+// them.
+func Wrap(conn net.Conn, free func()) net.Conn {
+	return wrappedConn{
+		Conn: conn,
+		free: free,
+	}
+}
+
+// Close frees the tracked connection and closes the underlying net.Conn.
+func (w wrappedConn) Close() error {
+	w.free()
+	return w.Conn.Close()
+}

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -1,0 +1,86 @@
+package connlimit
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWrapClose(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	limit := 3
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	errCh := make(chan error, 1)
+	connCh := make(chan net.Conn, 1)
+	go func() {
+		defer l.Close()
+
+		lim := NewLimiter(Config{
+			MaxConnsPerClientIP: limit,
+		})
+
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				errCh <- err
+				return
+			}
+
+			free, err := lim.Accept(conn)
+			if err != nil {
+				errCh <- err
+				return
+			}
+
+			conn = Wrap(conn, free)
+			select {
+			case connCh <- conn:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	// Max out connections
+	conns := make([]net.Conn, 0, limit)
+	for i := 0; i < limit; i++ {
+		conn, err := net.DialTimeout("tcp", l.Addr().String(), 2*time.Second)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		select {
+		case c := <-connCh:
+			conns = append(conns, c)
+			defer c.Close()
+		case err := <-errCh:
+			t.Fatalf("error from server goroutine: %v", err)
+		}
+	}
+
+	// Close one and assert it was freed by creating a new connection
+	require.NoError(t, conns[0].Close())
+
+	conn, err := net.DialTimeout("tcp", l.Addr().String(), 2*time.Second)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	select {
+	case c := <-connCh:
+		// Yay! Connected as expected!
+		c.Close()
+	case err := <-errCh:
+		// An error from the limiter here indicates a problem with the
+		// wrapper calling free()
+		t.Fatalf("error from server goroutine: %v", err)
+	}
+}


### PR DESCRIPTION
The Wrap func returns a net.Conn that calls free() when being closed.
Useful when tracking connections handed off to libraries like
https://github.com/hashicorp/raft which call Close on conns with no
callback or other ability to call free().