### PR TITLE
ci: Run CI workflow on merges to master and all PRs.

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -2,6 +2,7 @@ name: Build and Test Workflow
 
 on:
   pull_request:
+  push:
     branches: ["master"]
 
 jobs:


### PR DESCRIPTION
The CI suite should run when a PR is merged into the default branch. In some cases, development may use "twigs" for larger and more complex features, so allow CI to run on all PRs and not just ones that target master.

